### PR TITLE
Fix for Issue #10 - malformed metric names when deployed as a WAR

### DIFF
--- a/src/groovy/org/grails/plugins/yammermetrics/groovy/GroovierMetrics.groovy
+++ b/src/groovy/org/grails/plugins/yammermetrics/groovy/GroovierMetrics.groovy
@@ -6,15 +6,17 @@ import org.codehaus.groovy.reflection.ReflectionUtils
 import java.util.concurrent.TimeUnit
 
 class GroovierMetrics extends Metrics {
+	// ignore org.springsource.loaded.ri.ReflectiveInterceptor when not running as a war, and ignore this class for convenience
+	static final List<String> extraIgnoredPackages = ["org.springsource.loaded.ri", "org.grails.plugins.yammermetrics.groovy"]
 
     private GroovierMetrics() { super() }
 
     static com.yammer.metrics.core.Meter newMeter(String meterName){
-        return newMeter(ReflectionUtils.getCallingClass(2), meterName, meterName, TimeUnit.SECONDS)
+        return newMeter(ReflectionUtils.getCallingClass(0, extraIgnoredPackages), meterName, meterName, TimeUnit.SECONDS)
     }
 
     static com.yammer.metrics.core.Timer newTimer(String timerName){
-        return newTimer(ReflectionUtils.getCallingClass(2), timerName )
+        return newTimer(ReflectionUtils.getCallingClass(0, extraIgnoredPackages), timerName )
     }
 
     static com.yammer.metrics.core.Timer newTimer(String className, String timerName){


### PR DESCRIPTION
Please consider the following solution to this problem. The behavior I observed was that when running as a WAR, ReflectionUtils.getCallingClass(2), returns different results than when running with run-app.

When running with run-app the 0-3 entries are:
0: org.springsource.loaded.ri.ReflectiveInterceptor
1: org.grails.plugins.yammermetrics.groovy.GroovierMetrics
2: [instrumented class]
3: java.lang.reflect.Constructor OR [instrumented class]$$EnhancerByCGLIB$$89abcdef

When running with run-war the 0-3 entries are:
0: org.grails.plugins.yammermetrics.groovy.GroovierMetrics
1: [instrumented class]
2: java.lang.reflect.Constructor OR [instrumented class]$$EnhancerByCGLIB$$89abcdef
3: org.codehaus.groovy.grails.commons.AbstractGrailsClass OR java.lang.reflect.Constructor

My solution is to blacklist packages that may occur before the instrumented class, such that entry 0 will always be the desired class.
